### PR TITLE
Fix PactSharp compilation warnings

### DIFF
--- a/PactSharp/PactClient.cs
+++ b/PactSharp/PactClient.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -197,7 +196,7 @@ public class PactClient
                 {
                     respDict[key] = value.Deserialize<PactCommandResponse>(PactJsonOptions);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     throw; // TODO: Error handling
                 }
@@ -263,6 +262,7 @@ public class PactClient
         }
         catch (Exception e)
         {
+            Console.WriteLine($"Exception: {e}");
             return null;
         }
     }

--- a/PactSharp/Services/InMemorySettingsService.cs
+++ b/PactSharp/Services/InMemorySettingsService.cs
@@ -11,13 +11,14 @@ public class InMemorySettingsService : ISettingsService
         Settings = settings;
     }
     
-    public async Task<SettingsModel> GetSettingsAsync()
+    public Task<SettingsModel> GetSettingsAsync()
     {
-        return Settings;
+        return Task.FromResult(Settings);
     }
 
-    public async Task SaveSettingsAsync(SettingsModel settings)
+    public Task SaveSettingsAsync(SettingsModel settings)
     {
         Settings = settings;
+        return Task.CompletedTask;
     }
 }

--- a/PactSharp/Services/NullCacheService.cs
+++ b/PactSharp/Services/NullCacheService.cs
@@ -27,7 +27,7 @@ public class NullCacheService : ICacheService
         return cached.Unwrap<T>();
     }
 
-    public async Task<bool> SetItem<T>(T item, int expirySeconds = 0) where T : ICacheable
+    public Task<bool> SetItem<T>(T item, int expirySeconds = 0) where T : ICacheable
     {
         var cached = Get(item);
         var length = expirySeconds == 0 ? TimeSpan.FromSeconds(3600) : TimeSpan.FromSeconds(expirySeconds);
@@ -45,7 +45,7 @@ public class NullCacheService : ICacheService
             _buffer[item.CacheKey].Dirty = true;
         }
 
-        return true;
+        return Task.FromResult(true);
     }
 
     public async Task<int> InvalidatePrefix(string prefix)
@@ -85,21 +85,21 @@ public class NullCacheService : ICacheService
     private CachedItem Get(ICacheable item) => Get(item.CacheKey);
     private CachedItem Get(string key) => _buffer.ContainsKey(key) ? _buffer[key] : null;
     
-    private async Task<bool> Evict(CachedItem item)
+    private Task<bool> Evict(CachedItem item)
     {
         item.Dirty = true;
         _buffer.Remove(item.Key);
-        return true;
+        return Task.FromResult(true);
     }
 
-    public async Task<bool> Flush()
+    public Task<bool> Flush()
     {
-        return true;
+        return Task.FromResult(true);
     }
 
-    public async Task<bool> Initialize()
+    public Task<bool> Initialize()
     {
-        return true;
+        return Task.FromResult(true);
     }
 
     internal static string WithPrefix(string key) => "$cache$" + key;

--- a/PactSharp/Types/PactCommand.cs
+++ b/PactSharp/Types/PactCommand.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;

--- a/PactSharp/Types/PactCommandResponse.cs
+++ b/PactSharp/Types/PactCommandResponse.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Text.Json.Serialization;
 
 namespace PactSharp.Types;

--- a/PactSharp/Types/PactContinuation.cs
+++ b/PactSharp/Types/PactContinuation.cs
@@ -1,11 +1,13 @@
+#nullable enable
+
 namespace PactSharp.Types;
 
 public class PactContinuation
 {
     public bool? Executed { get; set; }
-    public string PactId { get; set; }
+    public string PactId { get; set; } = "";
     public int Step { get; set; }
     public int StepCount { get; set; }
-    public PactContinuationMetadata Continuation { get; set; }
+    public PactContinuationMetadata Continuation { get; set; } = new PactContinuationMetadata();
     public PactYield? Yield { get; set; }
 }

--- a/PactSharp/Types/PactExecPayload.cs
+++ b/PactSharp/Types/PactExecPayload.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
@@ -5,8 +7,8 @@ namespace PactSharp.Types;
 
 public class PactExecPayload
 {
-    public string Code { get; set; }
+    public string Code { get; set; } = "";
     public JsonNode? Data { get; set; } = new JsonObject();
 
-    [JsonIgnore] public JsonObject DataAsObject => Data?.AsObject();
+    [JsonIgnore] public JsonObject? DataAsObject => Data?.AsObject();
 }

--- a/PactSharp/Types/PactYield.cs
+++ b/PactSharp/Types/PactYield.cs
@@ -1,7 +1,9 @@
+#nullable enable
+
 namespace PactSharp.Types;
 
 public class PactYield
 {
-    public Dictionary<string, object> Data { get; set; }
+    public Dictionary<string, object> Data { get; set; } = new ();
     public PactProvenance? Provenance { get; set; }
 }

--- a/PactSharp/Types/StringCoercingJsonConverter.cs
+++ b/PactSharp/Types/StringCoercingJsonConverter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 


### PR DESCRIPTION
I don't think this should cause any regressions, but if it does it'll probably be because I'm setting some defaults as empty strings and added a couple of `?`s in some json objects.